### PR TITLE
Various QML fixes

### DIFF
--- a/qml/HydrogenWebView.qml
+++ b/qml/HydrogenWebView.qml
@@ -63,7 +63,7 @@ WebViewFlickable {
             case "webview:notificationCount":
                 app.coverTitle = qsTr("Messages")
                 app.notificationCount = data.count
-                app.coverMessages = data.mostRecent
+                app.coverMessages = data.coverPreview
                 break
             case "embed:linkclicked":
                 var url = '/^http:\/\/localhost/'

--- a/qml/HydrogenWebView.qml
+++ b/qml/HydrogenWebView.qml
@@ -63,7 +63,7 @@ WebViewFlickable {
             case "webview:notificationCount":
                 app.coverTitle = qsTr("Messages: %1").arg(data.count)
                 app.notificationCount = data.count
-                app.coverMessages = data.top5
+                app.coverMessages = data.mostRecent
                 break
             case "embed:linkclicked":
                 var url = '/^http:\/\/localhost/'

--- a/qml/HydrogenWebView.qml
+++ b/qml/HydrogenWebView.qml
@@ -61,7 +61,7 @@ WebViewFlickable {
                 console.log("webapp-log: " + JSON.stringify(data))
                 break
             case "webview:notificationCount":
-                app.coverTitle = qsTr("Messages: %1").arg(data.count)
+                app.coverTitle = qsTr("Messages")
                 app.notificationCount = data.count
                 app.coverMessages = data.mostRecent
                 break

--- a/qml/HydrogenWebView.qml
+++ b/qml/HydrogenWebView.qml
@@ -30,7 +30,8 @@ WebViewFlickable {
             text: qsTr('App Settings')
             onClicked: pageStack.push(Qt.resolvedUrl("pages/AppSettingsPage.qml"))
         }
-        MenuItem{
+        MenuItem {
+            visible: enabled
             enabled: app.isSettingsAvailable
             text: qsTr('Hydrogen Settings')
             onClicked: enterSettingsView()

--- a/qml/HydrogenWebView.qml
+++ b/qml/HydrogenWebView.qml
@@ -61,7 +61,7 @@ WebViewFlickable {
                 console.log("webapp-log: " + JSON.stringify(data))
                 break
             case "webview:notificationCount":
-                app.coverTitle = qsTr("Messages")
+                app.coverTitle = ""
                 app.notificationCount = data.count
                 app.coverMessages = data.coverPreview
                 break

--- a/qml/HydrogenWebView.qml
+++ b/qml/HydrogenWebView.qml
@@ -1,6 +1,8 @@
 // Copyright © 2021-2023 Thilo Kogge (thigg)
 // Copyright © 2023 The SailfishOS Hackathon Bucharest Team
 //
+// SPDX-FileCopyrightText: 2024 Mirian Margiani
+//
 // SPDX-License-Identifier: Apache-2.0
 
 import QtQuick 2.0
@@ -23,10 +25,17 @@ WebViewFlickable {
 
     quickScroll: false
     flickableDirection: Flickable.VerticalFlick
+
     PullDownMenu {
-        // Disable when in a room
-        visible: ! /\/room\/[^/]+$/.test(webview.url.toString())
-        MenuItem{
+        // Workaround for bug #42:
+        // Enable on the sessions view (that's usually not scrollable),
+        // but make sure it is disabled in the sessions list view and in
+        // all rooms.
+        visible: /\/session$/.test(webview.url.toString()) ||
+                 (!/\/room\/[^/]+$/.test(webview.url.toString()) &&
+                  !/\/session\/[^/]+$/.test(webview.url.toString()))
+
+        MenuItem {
             text: qsTr('App Settings')
             onClicked: pageStack.push(Qt.resolvedUrl("pages/AppSettingsPage.qml"))
         }

--- a/qml/HydrogenWebViewPage.qml
+++ b/qml/HydrogenWebViewPage.qml
@@ -1,6 +1,8 @@
 // Copyright © 2021-2023 Thilo Kogge (thigg)
 // Copyright © 2023 The SailfishOS Hackathon Bucharest Team
 //
+// SPDX-FileCopyrightText: 2024 Mirian Margiani
+//
 // SPDX-License-Identifier: Apache-2.0
 
 import QtQuick 2.0
@@ -17,10 +19,22 @@ WebViewPage {
         id: hydrogenwebview
         anchors.fill: parent
     }
+
+    Rectangle {
+        id: loadingBackground
+        anchors.fill: parent
+        color: Theme.highlightDimmerColor
+        visible: opacity > 0.0
+        Behavior on opacity { FadeAnimator{} }
+        opacity: hydrogenwebview.webView.loaded ? 0.0 : 1.0
+    }
+
     BusyLabel {
         running: !hydrogenwebview.webView.loaded
-        // break binding after first load:
-        onRunningChanged: { if (hydrogenwebview.webView.loaded) running = false }
-        Component.onCompleted: text = Fact.get()
+        text: Fact.get()
+        onRunningChanged: {
+            // break binding after first load
+            if (hydrogenwebview.webView.loaded) running = false
+        }
     }
 }

--- a/qml/HydrogenWebViewPage.qml
+++ b/qml/HydrogenWebViewPage.qml
@@ -31,10 +31,17 @@ WebViewPage {
 
     BusyLabel {
         running: !hydrogenwebview.webView.loaded
-        text: Fact.get()
         onRunningChanged: {
             // break binding after first load
             if (hydrogenwebview.webView.loaded) running = false
+        }
+
+        Component.onCompleted: {
+            if (appConfig.showFunFacts) {
+                // the property must be set here, otherwise
+                // we lose the default text
+                text = Fact.get()
+            }
         }
     }
 }

--- a/qml/components/HydrogenNotifier.qml
+++ b/qml/components/HydrogenNotifier.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.2      // not 2.0, because Instantiator
+import QtQuick 2.2  // not 2.0, because Instantiator
+import QtQml 2.2  // for Instantiator
 import Sailfish.Silica 1.0
 import Nemo.Notifications 1.0
 

--- a/qml/components/HydrogenNotifier.qml
+++ b/qml/components/HydrogenNotifier.qml
@@ -154,7 +154,7 @@ Item { id: root
     Component { id: template; Notification {
          property string internalId
          category: "im.received"
-         appName: qsTr("Hydrogen")
+         appName: "Hydrogen"  // app name is not translated
          appIcon: "image://theme/harbour-hydrogen"
          //summary: "Notification summary"
          //body: "Notification body"

--- a/qml/cover/HydrogenCover.qml
+++ b/qml/cover/HydrogenCover.qml
@@ -72,13 +72,13 @@ CoverBackground {
     CoverActionList {
         id: coverAction
         CoverAction {
-            iconSource: "image://theme/icom-cover-sync"
+            iconSource: "image://theme/icon-cover-sync"
         }
         CoverAction {
-            iconSource: "image://theme/icom-cover-message"
+            iconSource: "image://theme/icon-cover-message"
         }
         CoverAction {
-            iconSource: "image://theme/icom-cover-new"
+            iconSource: "image://theme/icon-cover-new"
         }
     }
 }

--- a/qml/cover/HydrogenCover.qml
+++ b/qml/cover/HydrogenCover.qml
@@ -1,6 +1,8 @@
 // Copyright © 2021-2023 Thilo Kogge (thigg)
 // Copyright © 2023 The SailfishOS Hackathon Bucharest Team
 //
+// SPDX-FileCopyrightText: 2024 Mirian Margiani
+//
 // SPDX-License-Identifier: Apache-2.0
 
 import QtQuick 2.0

--- a/qml/cover/HydrogenCover.qml
+++ b/qml/cover/HydrogenCover.qml
@@ -50,6 +50,7 @@ CoverBackground {
         text: app.coverTitle
         color: Theme.highlightColor
         wrapMode: Text.Wrap
+        height: visible ? implicitHeight : 0
 
         width: parent.width - 2*Theme.horizontalPageMargin
         anchors {

--- a/qml/cover/HydrogenCover.qml
+++ b/qml/cover/HydrogenCover.qml
@@ -34,41 +34,87 @@ CoverBackground {
     Label {
         id: nameLabel
         text: "Hydrogen" // app name is not translated
-        x: parent.width  - (width +  Theme.paddingLarge)
-        y: parent.height - (height + Theme.paddingSmall*3)
+        anchors {
+            right: parent.right
+            rightMargin: Theme.horizontalPageMargin
+            bottom: coverActionArea.bottom
+            bottomMargin: Theme.paddingMedium
+        }
         font.pixelSize: Theme.fontSizeLarge
         color: hyHighlightColor
     }
 
     Label {
         id: titleLabel
-        visible: app.coverTitle.length > 0
+        visible: !!text
         text: app.coverTitle
-        width: parent.width - Theme.horizontalPageMargin
-        x: Theme.horizontalPageMargin
-        //y: Theme.paddingMedium
-        anchors.top: label.bottom
-        font.pixelSize: Theme.fontSizeExtraSmall
         color: Theme.highlightColor
         wrapMode: Text.Wrap
-    }
-    ColumnView { id: messageView
-        x: Theme.horizontalPageMargin
-        width: parent.width - Theme.horizontalPageMargin
-        height: parent.height - coverAction.height
-        anchors.top: titleLabel.bottom
-        anchors.horizontalCenter: parent.horizontalCenter
-        visible: app.coverMessages.length > 0
-        opacity: visible ? 1.0 : 0.4
-        Behavior on opacity { FadeAnimator { } }
 
-        itemHeight: Theme.itemSizeSmall/2
-        delegate: Label {
-            text: modelData
-            font.pixelSize: Theme.fontSizeTiny*0.8
-            wrapMode: Text.NoWrap
-            truncationMode: TruncationMode.Fade
-            width: messageView.width
+        width: parent.width - 2*Theme.horizontalPageMargin
+        anchors {
+            top: parent.top
+            topMargin: Theme.paddingMedium
+            horizontalCenter: parent.horizontalCenter
         }
+    }
+
+    ColumnView {
+        id: messageView
+        width: parent.width - 2*Theme.horizontalPageMargin
+        anchors {
+            top: titleLabel.bottom
+            topMargin: Theme.paddingMedium
+            bottom: nameLabel.top
+            bottomMargin: Theme.paddingMedium
+            horizontalCenter: parent.horizontalCenter
+        }
+
+        visible: opacity > 0.0
+        opacity: app.coverMessages.length > 0 ? 1.0 : 0.0
+        Behavior on opacity { FadeAnimator {} }
+        itemHeight: Theme.fontSizeSmall * 2
+
+        delegate: Item {
+            width: parent.width
+            height: Theme.fontSizeSmall * 2
+
+            Label {
+                id: countLabel
+                text: modelData.count
+                height: Theme.fontSizeSmall * 1.5
+                verticalAlignment: Text.AlignBottom
+                font.pixelSize: Theme.fontSizeSmall * 1.5
+                truncationMode: TruncationMode.Fade
+                color: Theme.secondaryHighlightColor
+                width: implicitWidth
+
+                anchors {
+                    left: parent.left
+                    verticalCenter: parent.verticalCenter
+                }
+            }
+
+            Label {
+                text: modelData.name
+                font.pixelSize: Theme.fontSizeSmall
+                truncationMode: TruncationMode.Fade
+                color: Theme.secondaryHighlightColor
+
+                anchors {
+                    left: countLabel.right
+                    leftMargin: Theme.paddingSmall
+                    right: parent.right
+                    baseline: countLabel.baseline
+                }
+            }
+        }
+    }
+
+    OpacityRampEffect {
+        direction: OpacityRamp.TopToBottom
+        sourceItem: messageView
+        offset: 0.6
+        slope: 1.5
     }
 }

--- a/qml/cover/HydrogenCover.qml
+++ b/qml/cover/HydrogenCover.qml
@@ -9,38 +9,39 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 CoverBackground {
-    readonly property color hyColor:               "#0dbd8b"
-    readonly property color hylightColor:          Theme.highlightFromColor(hyColor, Theme.ColorScheme)
-    //readonly property color secondaryHylightColor: Theme.secondaryHighlightFromColor(hyColor, Theme.ColorScheme)
-    //readonly property color dimmerHylightColor:    Theme.highlightDimmerFromColor(hyColor, Theme.ColorScheme)
-    readonly property color logoColor:             Theme.rgba(hyColor, Theme.OpacityFaint)
+    readonly property color hyColor: "#0dbd8b"
+    readonly property color hyHighlightColor: Theme.highlightFromColor(hyColor, Theme.colorScheme)
 
     Connections {
         target: app
         onCoverMessagesChanged: messageView.model = app.coverMessages
     }
-    Icon {
+
+    HighlightImage {
+        id: background
         z: -1
-        source: Qt.resolvedUrl("./hydrogen.svg" + "?" + logoColor)
-        anchors.horizontalCenter: parent.left
-        anchors.verticalCenter: parent.bottom
-        height: visible ? parent.height : 0
+        source: Qt.resolvedUrl("./hydrogen.svg")
+        anchors {
+            horizontalCenter: parent.left
+            verticalCenter: parent.bottom
+        }
+        height: parent.height
         fillMode: Image.PreserveAspectFit
-        opacity: visible ? 0.2 : 0.0
-        Behavior on opacity { FadeAnimator { duration: 1200 } }
-        //Behavior on height  { PropertyAnimation { duration: 1200 ; easing.type: Easing.InBounce } }
+        opacity: 0.15
+        color: hyHighlightColor
     }
+
     Label {
         id: nameLabel
-        text: qsTr("Hydrogen")
-        x: (parent.width  - (width +  Theme.paddingLarge))
-        y: visible ? (parent.height - (height + Theme.paddingSmall*3)) : parent.height + height
+        text: "Hydrogen" // app name is not translated
+        x: parent.width  - (width +  Theme.paddingLarge)
+        y: parent.height - (height + Theme.paddingSmall*3)
         font.pixelSize: Theme.fontSizeLarge
-        color:   visible ? Theme.secondaryColor : hylightColor
-        Behavior on color { ColorAnimation { duration: 2400 } }
-        Behavior on y { PropertyAnimation { duration: 2400 } }
+        color: hyHighlightColor
     }
-    Label { id: titleLabel
+
+    Label {
+        id: titleLabel
         visible: app.coverTitle.length > 0
         text: app.coverTitle
         width: parent.width - Theme.horizontalPageMargin

--- a/qml/cover/HydrogenCover.qml
+++ b/qml/cover/HydrogenCover.qml
@@ -68,17 +68,4 @@ CoverBackground {
             width: messageView.width
         }
     }
-
-    CoverActionList {
-        id: coverAction
-        CoverAction {
-            iconSource: "image://theme/icon-cover-sync"
-        }
-        CoverAction {
-            iconSource: "image://theme/icon-cover-message"
-        }
-        CoverAction {
-            iconSource: "image://theme/icon-cover-new"
-        }
-    }
 }

--- a/qml/harbour-hydrogen.qml
+++ b/qml/harbour-hydrogen.qml
@@ -1,6 +1,8 @@
 // Copyright © 2021-2023 Thilo Kogge (thigg)
 // Copyright © 2023 The SailfishOS Hackathon Bucharest Team
 //
+// SPDX-FileCopyrightText: 2024 Mirian Margiani
+//
 // SPDX-License-Identifier: Apache-2.0
 
 import QtQuick 2.0

--- a/qml/harbour-hydrogen.qml
+++ b/qml/harbour-hydrogen.qml
@@ -177,6 +177,7 @@ ApplicationWindow {
         path:  "app"
         property bool showNotifications: true
         property bool stickyNotifications: false
+        property bool showFunFacts: true
     }
     ConfigurationGroup  {
         id: wvConfig

--- a/qml/harbour-hydrogen.qml
+++ b/qml/harbour-hydrogen.qml
@@ -15,7 +15,7 @@ import "components"
 
 ApplicationWindow {
     id: app
-    cover: HydrogenCover{}
+    cover: Component { HydrogenCover {} }
 
     allowedOrientations: Orientation.All
     property int notificationCount: 0

--- a/qml/harbour-hydrogen.qml
+++ b/qml/harbour-hydrogen.qml
@@ -31,15 +31,17 @@ ApplicationWindow {
 
     HydrogenNotifier { id: notifier }
 
-    /* array of string.
-       Use it something like below.
-       Note that you can't usefully push() and pop() QML var type arrays.
+    /* Array of objects: {name: "Name", count: 5}
 
-            addMessage(message) {
-                var msgs = coverMessages
-                msgs.splice (message)
-                coverMessage = msgs
-            }
+       These messages will be shown on the cover with an optional
+       title. Note that push() and pop() will not update the cover.
+       You must reassign the property to trigger coverMessagesChanged signals.
+
+       This does the trick:
+         coverMessages.push(message)
+         coverMessages = coverMessages
+
+       Note: the title should stay empty if the messages are self-explanatory.
     */
     property var coverMessages: []
     property string coverTitle: "" // e.g. qsTr("New Messages")

--- a/qml/notificationCount.js
+++ b/qml/notificationCount.js
@@ -34,16 +34,20 @@ function refreshSession() {
         };
         request.onsuccess = function(event) {
           var notificationCount = request.result.reduce((sum, item) => sum + item.notificationCount, 0);
-          // Most recent 10 discussions with unread:
-          let mostRecent = request.result.filter(item => !!item.notificationCount)
+
+          // Most recent bunch of discussions with unread
+          let mostRecentCount = 20;
+          let coverPreview = request.result.filter(item => !!item.notificationCount)
                 .sort((x,y) => x.lastMessageTimestamp - y.lastMessageTimestamp)
-                .slice(-10).map(item => item.name || item.heroes[0])
-                .reverse();
+                .slice(-mostRecentCount).map(item => ({
+                    name: item.name || item.heroes[0],
+                    count: item.notificationCount,
+                })).reverse();
 
           var customEvent = new CustomEvent("framescript:notificationCount", {
               detail: {
                   count: notificationCount,
-                  mostRecent: mostRecent
+                  coverPreview: coverPreview,
               }
           });
           document.dispatchEvent(customEvent);

--- a/qml/notificationCount.js
+++ b/qml/notificationCount.js
@@ -1,6 +1,8 @@
 // Copyright © 2021-2023 Thilo Kogge (thigg)
 // Copyright © 2023 The SailfishOS Hackathon Bucharest Team
 //
+// SPDX-FileCopyrightText: 2024 Mirian Margiani
+//
 // SPDX-License-Identifier: Apache-2.0
 
 function getCurrentSession() {

--- a/qml/notificationCount.js
+++ b/qml/notificationCount.js
@@ -35,13 +35,17 @@ function refreshSession() {
         request.onsuccess = function(event) {
           var notificationCount = request.result.reduce((sum, item) => sum + item.notificationCount, 0);
           // Most recent 10 discussions with unread:
-          let top5 = request.result.filter(item => !!item.notificationCount)
+          let mostRecent = request.result.filter(item => !!item.notificationCount)
                 .sort((x,y) => x.lastMessageTimestamp - y.lastMessageTimestamp)
                 .slice(-10).map(item => item.name || item.heroes[0])
                 .reverse();
 
-          var customEvent = new CustomEvent("framescript:notificationCount",
-                           { detail: { count: notificationCount, top5 }});
+          var customEvent = new CustomEvent("framescript:notificationCount", {
+              detail: {
+                  count: notificationCount,
+                  mostRecent: mostRecent
+              }
+          });
           document.dispatchEvent(customEvent);
         };
     }

--- a/qml/pages/AppSettingsPage.qml
+++ b/qml/pages/AppSettingsPage.qml
@@ -6,6 +6,9 @@ import QtQuick 2.6
 import Sailfish.Silica 1.0
 
 Page {
+    id: root
+    allowedOrientations: Orientation.All
+
     SilicaFlickable{
         anchors.fill: parent
         contentHeight: col.height

--- a/qml/pages/AppSettingsPage.qml
+++ b/qml/pages/AppSettingsPage.qml
@@ -48,6 +48,16 @@ Page {
                            !appConfig.stickyNotifications
             }
 
+            TextSwitch {
+                checked: appConfig.showFunFacts
+                text: qsTr("Show fun facts while loading")
+                description: qsTr("If enabled, the app will show " +
+                                  "fun science facts about Hydrogen " +
+                                  "during startup.")
+                onClicked: appConfig.showFunFacts =
+                           !appConfig.showFunFacts
+            }
+
             SectionHeader {
                 text: qsTr("Web View")
             }

--- a/qml/pages/AppSettingsPage.qml
+++ b/qml/pages/AppSettingsPage.qml
@@ -1,5 +1,7 @@
 // This file is part of harbour-hydrogen
 // Copyright (c) 2023 Peter G. (nephros)
+//
+// SPDX-FileCopyrightText: 2024 Mirian Margiani
 // SPDX-License-Identifier: Apache-2.0
 
 import QtQuick 2.6
@@ -9,62 +11,68 @@ Page {
     id: root
     allowedOrientations: Orientation.All
 
-    SilicaFlickable{
+    SilicaFlickable {
         anchors.fill: parent
         contentHeight: col.height
+
         Column {
             id: col
             spacing: Theme.paddingLarge
             bottomPadding: Theme.itemSizeLarge
-            width: parent.width - Theme.horizontalPageMargin
-            PageHeader{ title:  Qt.application.name + " " + qsTr("Settings", "page title") }
+            width: parent.width
+
+            PageHeader {
+                title: qsTr("Settings", "page title")
+            }
+
             SectionHeader {
-                width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
                 text: qsTr("Notifications")
             }
-            TextSwitch{ id: notifysw
-                width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
+
+            TextSwitch {
+                id: notifysw
                 checked: appConfig.showNotifications
-                automaticCheck: true
-                text: qsTr("Show Notifications")
-                //description: qsTr("If enabled, ... .")
-                onClicked: appConfig.showNotifications = checked
+                text: qsTr("Show notifications")
+                onClicked: appConfig.showNotifications =
+                           !appConfig.showNotifications
             }
-            TextSwitch{
+
+            TextSwitch {
                 enabled: notifysw.checked
-                width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
                 checked: appConfig.stickyNotifications
-                automaticCheck: true
-                text: qsTr("Sticky Notifications")
-                description: qsTr("If enabled, the app will update a single notification (as opposed to sending a new one each time).")
-                onClicked: appConfig.stickyNotifications = checked
+                text: qsTr("Sticky notifications")
+                description: qsTr("If enabled, the app will update a single " +
+                                  "notification (as opposed to sending a new " +
+                                  "one each time).")
+                onClicked: appConfig.stickyNotifications =
+                           !appConfig.stickyNotifications
             }
+
             SectionHeader {
-                width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
                 text: qsTr("Web View")
             }
+
             Label {
-                width: parent.width - Theme.horizontalPageMargin
-                anchors.horizontalCenter: parent.horizontalCenter
-                //color: Theme.secondaryColor
+                width: parent.width - 2*x
+                x: Theme.horizontalPageMargin
+                color: Theme.highlightColor
                 font.pixelSize: Theme.fontSizeSmall
                 wrapMode: Text.Wrap
-                text: qsTr("Restart the App to apply changes to any of the values below.")
+                text: qsTr("Restart the App to apply changes to any of " +
+                           "the values below.")
             }
-            ComboBox{
-                width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
-                label: qsTr("Theme Mode")
-                description: qsTr("Whether we will follow the Ambience style, or used fixed Light or Dark mode.")
+
+            ComboBox {
+                label: qsTr("Color theme")
+                description: qsTr("This setting defines whether the app will " +
+                                  "follow the current ambience style, or always " +
+                                  "use either dark or light mode.")
                 menu: ContextMenu {
-                    MenuItem { text: qsTr("Light Mode"); }
-                    MenuItem { text: qsTr("Dark Mode"); }
-                    MenuItem { text: qsTr("Follow Ambience"); }
+                    MenuItem { text: qsTr("Light mode"); }
+                    MenuItem { text: qsTr("Dark mode"); }
+                    MenuItem { text: qsTr("Follow ambience"); }
                 }
+
                 property bool ready: false
                 onCurrentIndexChanged: {
                     if (!ready) return
@@ -76,67 +84,45 @@ Page {
                     if (wvConfig.ambienceMode) currentIndex = wvConfig.ambienceMode
                     ready = true
                 }
+            }
 
-            }
-            Label {
-                anchors {
-                    // align to slider left
-                    left: zoomSlider.left
-                    leftMargin: zoomSlider.leftMargin //+ Theme.paddingLarge
-                    right: zoomSlider.right
-                    rightMargin: zoomSlider.rightMargin //+ Theme.paddingLarge
-                    topMargin: Theme.paddingMedium
-                }
-                text: qsTr("Scale user interface")
-                width: parent.width
-                color: Theme.secondaryHighlightColor
-                wrapMode: Text.Wrap
-            }
             Slider {
                 id: zoomSlider
                 width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
-                label: qsTr("Page Zoom factor")
+
+                label: qsTr("User interface scale factor")
                 minimumValue: 0.8
                 maximumValue: 4.3
                 stepSize: 0.2
                 value: wvConfig.zoom
-                valueText: "x" + value
-                onReleased:  { wvConfig.zoom = sliderValue }
-            }
-            Label {
-                anchors {
-                    // align to slider left
-                    left: zoomSlider.left
-                    leftMargin: zoomSlider.leftMargin //+ Theme.paddingLarge
-                    right: zoomSlider.right
-                    rightMargin: zoomSlider.rightMargin //+ Theme.paddingLarge
-                    topMargin: Theme.paddingMedium
+                valueText: value.toLocaleString(Qt.locale(), 'f', 2)
+                onReleased: {
+                    wvConfig.zoom = sliderValue
                 }
-                text: qsTr("Browser Memory")
-                width: parent.width
-                color: Theme.secondaryHighlightColor
-                wrapMode: Text.Wrap
             }
+
             Slider {
                 id: memSlider
                 width: parent.width
-                anchors.horizontalCenter: parent.horizontalCenter
-                label: qsTr("Memory Cache")
+
+                label: qsTr("Memory cache size")
                 minimumValue: 0
                 maximumValue: 11
                 stepSize: 0.5
-                value: wvConfig.memCache ? wvConfig.memCache: -1
+                value: wvConfig.memCache ? wvConfig.memCache : -1
                 valueText: {
                     if (sliderValue === 11) {
                         return qsTr("automatic")
                     } else if (sliderValue === 0) {
                         return qsTr("disabled")
                     } else {
-                        Math.round(sliderValue * 12.8) + qsTr("MB");
+                        return qsTr("%1 MB", "memory size, as in “10 megabytes”")
+                               .arg(Math.round(sliderValue * 12.8))
                     }
                 }
-                onReleased: wvConfig.memCache = Math.round(sliderValue)
+                onReleased: {
+                    wvConfig.memCache = Math.round(sliderValue)
+                }
             }
         }
     }


### PR DESCRIPTION
I fixed a bunch of papercuts:
- new cover page that follows Sailfish styling
- refactored the settings page to follow Sailfish styling
- added a new setting to disable fun facts while loading (I personally find them distracting, but I kept the new setting enabled by default, of course)
- removed qsTr() from app name in notifications, it's not translated in any current translations anyway
- added a dimmed background while loading to work around the glaring white screen that would otherwise show before the view is loaded
- disabled the pulley menu in the channels list to work around #42

Screenshots:
![screenshot-001](https://github.com/user-attachments/assets/cdad02a3-2212-4523-848f-3bd1cc222ade)
![screenshot-002](https://github.com/user-attachments/assets/b5d82e33-16c3-4e19-8312-2ef5e56f81c0)
![screenshot-003](https://github.com/user-attachments/assets/a4361ea9-71f6-4c88-becf-42bc439d8b19)
![screenshot-004](https://github.com/user-attachments/assets/a2984d59-83f8-4b76-8f09-f8d5e9055d6f)

