### PR TITLE
0.5.x

### DIFF
--- a/qml/harbour-hydrogen.qml
+++ b/qml/harbour-hydrogen.qml
@@ -82,7 +82,7 @@ ApplicationWindow {
     function cleanInvitation(link) {
         if (link) {
             var invit_raw = link.toString().split('#/')[1]
-            return encodeURIComponent(invit_raw.split('?')[0])
+            return invit_raw.split('?')[0]
         }
     }
 

--- a/qml/pages/AppSettingsPage.qml
+++ b/qml/pages/AppSettingsPage.qml
@@ -23,6 +23,7 @@ Page {
 
             PageHeader {
                 title: qsTr("Settings", "page title")
+                description: "harbour-hydrogen unreleased"
             }
 
             SectionHeader {

--- a/rpm/harbour-hydrogen.spec
+++ b/rpm/harbour-hydrogen.spec
@@ -6,18 +6,18 @@
 Name:       harbour-hydrogen
 
 # >> macros
-%define zipversion sfos-0.4.1
+%define zipversion 0.5.1
 # << macros
 
 Summary:    hydrogen, a matrix client
-Version:    0.4.1
-Release:    2
+Version:    0.5
+Release:    1
 Group:      Qt/Qt
 License:    ASL 2.0
 BuildArch:  noarch
 URL:        https://github.com/hydrogen-sailfishos/sfos-hydrogen
 Source0:    %{name}-%{version}.tar.bz2
-Source1:    https://github.com/hydrogen-sailfishos/hydrogen-web/releases/download/%{zipversion}/release-%{zipversion}.zip
+Source1:    https://github.com/element-hq/hydrogen-web/releases/download/v0.5.1/hydrogen-web-%{zipversion}.tar.gz
 Requires:   sailfishsilica-qt5 >= 0.10.9
 Requires:   libsailfishapp-launcher
 Requires:   sailfish-components-webview-qt5
@@ -60,7 +60,7 @@ then
   exit 1
 fi
 pushd hydrogen
-unzip %{SOURCE1}
+tar -xvzf %{SOURCE1}
 popd
 %endif
 

--- a/rpm/harbour-hydrogen.spec
+++ b/rpm/harbour-hydrogen.spec
@@ -68,7 +68,10 @@ mkdir -p hydrogen/target
 tar -C hydrogen/target -xvzf %{SOURCE1}
 
 # create config from sample
-mv hydrogen/target/config.sample.json hydrogen/target/config.json
+if [ ! -f hydrogen/target/config.json ]
+then
+    mv hydrogen/target/config.sample.json hydrogen/target/config.json
+fi
 %endif
 
 # >> setup

--- a/rpm/harbour-hydrogen.spec
+++ b/rpm/harbour-hydrogen.spec
@@ -6,18 +6,18 @@
 Name:       harbour-hydrogen
 
 # >> macros
-%define zipversion 0.5.1
+%define zipversion sfos-v0.5.1
 # << macros
 
 Summary:    hydrogen, a matrix client
-Version:    0.5.0
+Version:    0.5.1
 Release:    1
 Group:      Qt/Qt
 License:    ASL 2.0
 BuildArch:  noarch
 URL:        https://github.com/hydrogen-sailfishos/harbour-hydrogen
 Source0:    %{name}-%{version}.tar.bz2
-Source1:    https://github.com/element-hq/hydrogen-web/releases/download/v0.5.1/hydrogen-web-%{zipversion}.tar.gz
+Source1:    https://github.com/hydrogen-sailfishos/hydrogen-web/releases/download/%{zipversion}/hydrogen-web-%{zipversion}.tar.gz
 Requires:   sailfishsilica-qt5 >= 0.10.9
 Requires:   libsailfishapp-launcher
 Requires:   sailfish-components-webview-qt5

--- a/rpm/harbour-hydrogen.spec
+++ b/rpm/harbour-hydrogen.spec
@@ -54,14 +54,21 @@ Links:
 %prep
 %setup -q -n %{name}-%{version}
 %if 0%{?sailfishos_version}
+# add release version to QML app
 sed -i "s/unreleased/%{version}/" qml/pages/AppSettingsPage.qml
 if [ ! -f %{SOURCE1} ]
 then
   echo "Missing %{SOURCE1}"
   exit 1
 fi
-mkdir -p hydrogen/target # supports building locally
+# we use hydrogen/target because locally fetching hydrogen-web in that folder builds it there
+mkdir -p hydrogen/target
+
+# but this is the pre-built web app from github
 tar -C hydrogen/target -xvzf %{SOURCE1}
+
+# create config from sample
+mv hydrogen/target/config.sample.json hydrogen/target/config.json
 %endif
 
 # >> setup

--- a/rpm/harbour-hydrogen.spec
+++ b/rpm/harbour-hydrogen.spec
@@ -10,12 +10,12 @@ Name:       harbour-hydrogen
 # << macros
 
 Summary:    hydrogen, a matrix client
-Version:    0.5
+Version:    0.5.0
 Release:    1
 Group:      Qt/Qt
 License:    ASL 2.0
 BuildArch:  noarch
-URL:        https://github.com/hydrogen-sailfishos/sfos-hydrogen
+URL:        https://github.com/hydrogen-sailfishos/harbour-hydrogen
 Source0:    %{name}-%{version}.tar.bz2
 Source1:    https://github.com/element-hq/hydrogen-web/releases/download/v0.5.1/hydrogen-web-%{zipversion}.tar.gz
 Requires:   sailfishsilica-qt5 >= 0.10.9
@@ -43,11 +43,11 @@ Categories:
  - InstantMessaging
  - Network
 Custom:
-  Repo: https://github.com/hydrogen-sailfishos/sfos-hydrogen
-PackageIcon: https://raw.githubusercontent.com/hydrogen-sailfishos/sfos-hydrogen/hackathon/icons/svgs/harbour-hydrogen.svg
+  Repo: https://github.com/hydrogen-sailfishos/harbour-hydrogen
+PackageIcon: https://raw.githubusercontent.com/hydrogen-sailfishos/harbour-hydrogen/hackathon/icons/svgs/harbour-hydrogen.svg
 Links:
-  Homepage: https://github.com/hydrogen-sailfishos/sfos-hydrogen
-  Bugtracker: https://github.com/hydrogen-sailfishos/sfos-hydrogen/issues
+  Homepage: https://github.com/hydrogen-sailfishos/harbour-hydrogen
+  Bugtracker: https://github.com/hydrogen-sailfishos/harbour-hydrogen/issues
   Hackathon: https://github.com/orgs/hydrogen-sailfishos/projects/1/
 %endif
 

--- a/rpm/harbour-hydrogen.spec
+++ b/rpm/harbour-hydrogen.spec
@@ -54,14 +54,14 @@ Links:
 %prep
 %setup -q -n %{name}-%{version}
 %if 0%{?sailfishos_version}
+sed -i "s/unreleased/%{version}/" qml/pages/AppSettingsPage.qml
 if [ ! -f %{SOURCE1} ]
 then
   echo "Missing %{SOURCE1}"
   exit 1
 fi
-pushd hydrogen
-tar -xvzf %{SOURCE1}
-popd
+mkdir -p hydrogen/target # supports building locally
+tar -C hydrogen/target -xvzf %{SOURCE1}
 %endif
 
 # >> setup


### PR DESCRIPTION
Our contribution to open a _blank target was [merged](https://github.com/element-hq/hydrogen-web/pull/1158).
Hydrogen-web 0.5.1 was realeased with that - and we can just use those artefacts.

However I have the impression that channel joining is not working, if you click a such link. I have removed some encoding, but don't have conclusive tests...

---

Also: version in About page #50 

Builds at: https://build.sailfishos.org/package/show/home:b100dian:sfos-hydrogen/harbour-hydrogen

---
Update: Back to our own hydrogen build with 0.5.1 + patches by @ichthyosaurus 