### PR TITLE
Show current app version in settings

### DIFF
--- a/qml/pages/AppSettingsPage.qml
+++ b/qml/pages/AppSettingsPage.qml
@@ -23,6 +23,9 @@ Page {
 
             PageHeader {
                 title: qsTr("Settings", "page title")
+
+                // The version number must be updated manually when a new version is released!
+                description: qsTr("Version %1", "app version").arg("0.4.2")
             }
 
             SectionHeader {


### PR DESCRIPTION
This adds the current app version (not to be confused with the packaged hydrogen version) to the settings page.

It must be updated *manually* when the app is released. This is quite annoying, so it's not the best fix... I usually automate it in my apps by passing the version number from yaml/rpm spec as a `#define` to my app (like this: https://github.com/Pretty-SFOS/opal/blob/main/snippets/opal-cached-defines.md).

The same could be done here if a compiled exe is added anyway for #25.

Fixes #50 .